### PR TITLE
Merge 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## v0.2.0
+
+* Fix filter `Opeartors`
+* Add `excludeFromIndex` decorator to exclude a specific property from indexes
+
 ## v0.1.2
 
 * Export `TYPES` for `Datastore` binding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v0.2.0
 
+* Update [Wiki](https://github.com/pflima92/google-cloud-datastore-inversify/wiki)
 * Fix filter `Opeartors`
 * Add `excludeFromIndex` decorator to exclude a specific property from indexes
+* Add `entityOptions` for custom configurations
+* Add `excludeExtraneousValues` that allows ensure all properties from the type class
 
 ## v0.1.2
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Inversify - Google Cloud Datastore 
 
 [![Build Status](https://travis-ci.com/pflima92/google-cloud-datastore-inversify.svg?branch=master)](https://travis-ci.com/pflima92/google-cloud-datastore-inversify)
+[![npm version](https://badge.fury.io/js/inversify-datastore.svg)](https://badge.fury.io/js/inversify-datastore)
+[![Dependencies](https://david-dm.org/pflima92/google-cloud-datastore-inversify.svg)](https://david-dm.org/pflima92/google-cloud-datastore-inversify#info=dependencies)
 
 Some utilities for the development of Google Cloud Datastore applications using Inversify.
 
@@ -9,7 +11,7 @@ Some utilities for the development of Google Cloud Datastore applications using 
 You can install `inversify-datastore` using npm:
 
 ```sh
-npm install inversify inversify-datastore reflect-metadata --save
+npm install inversify inversify-datastore reflect-metadata @google-cloud/datastore --save
 ```
 
 The `inversify-datastore` type definitions are included in the npm module and require TypeScript 2.0.
@@ -53,28 +55,15 @@ let container = new Container();
 let datastore = new Datastore();
 
 // set up bindings
-container.bind<Datastore>(TYPES.Datastore).toConstantValue(datastore);
+container.bind(TYPES.Datastore).toConstantValue(datastore);
 
 // Bind your repositories
 container.bind<UserRepository>(UserRepository).toSelf();
-
-// Bind your components
-container.bind<FooService>('FooService').to(FooService);
-
-@injectable()
-class FooService {
-
-    repository: UserRepository;
-
-    constructor(@inject(UserRepository) repository: UserRepository){
-        this.repository = repository;
-    }
-}
-
 ```
-## Examples
 
-Some examples can be found at the [google-cloud-datastore-inversify-example](https://github.com/pflima92/google-cloud-datastore-inversify-example) repository.
+## Documentation
+
+Read the [basics](https://github.com/pflima92/google-cloud-datastore-inversify#the-basics) for a 2 minutes introduction. After that, head to the [documentation](https://github.com/pflima92/google-cloud-datastore-inversify/wiki), or checkout the [source code](https://github.com/pflima92/google-cloud-datastore-inversify-example) of the demo for an example usage.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inversify-datastore",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Some utilities for the development of Google Cloud Datastore applications using Inversify",
   "main": "lib/index.js",
   "jsnext:main": "es/index.js",

--- a/src/base_repository.ts
+++ b/src/base_repository.ts
@@ -168,7 +168,7 @@ function getIdProperty(target: any) {
 }
 
 function getExcludeFromIndexes(target: any): string[] {
-  return Reflect.getMetadata(METADATA_KEY.unindexed, target) || [];
+  return Reflect.getMetadata(METADATA_KEY.excludeFromIndexes, target) || [];
 }
 
 interface EntityRequest {

--- a/src/base_repository.ts
+++ b/src/base_repository.ts
@@ -135,10 +135,13 @@ export class BaseRepository<T> implements interfaces.CrudRepository<T> {
     }
 
     const key = this.createKey(kind, keyValue, ns);
+    const data = classToPlain(concreteClass);
+    const excludeFromIndexes = getExcludeFromIndexes(concreteClass);
 
     return {
       key: key,
-      data: classToPlain(concreteClass),
+      data: data,
+      excludeFromIndexes: excludeFromIndexes
     };
   }
 
@@ -164,7 +167,12 @@ function getIdProperty(target: any) {
   return Reflect.getMetadata(METADATA_KEY.entityId, target);
 }
 
+function getExcludeFromIndexes(target: any): string[] {
+  return Reflect.getMetadata(METADATA_KEY.unindexed, target) || [];
+}
+
 interface EntityRequest {
   key: any;
   data: any;
+  excludeFromIndexes: string[];
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,7 @@ const METADATA_KEY = {
   repository: "_repository",
   entity: "_entity",
   entityId: "_entity-id",
-  unindexed: "_unindexed",
+  excludeFromIndexes: "_excludeFromIndexes",
 };
 
 const CONTRAINTS = {

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -50,12 +50,12 @@ export function id(validationOptions?: ValidationOptions) {
 }
 
 /**
- * The field decorated will be unindexed.
+ * The field decorated will be excluded from entity indexes.
  */
-export function unindexed() {
+export function excludeFromIndex() {
   return (target: object, propertyKey: string) => {
-    let unIndexedFields = Reflect.getMetadata(METADATA_KEY.unindexed, target) || [];
-    unIndexedFields.push(propertyKey);
-    Reflect.defineMetadata(METADATA_KEY.unindexed, unIndexedFields, target);
+    let excludeFromIndexes = Reflect.getMetadata(METADATA_KEY.excludeFromIndexes, target) || [];
+    excludeFromIndexes.push(propertyKey);
+    Reflect.defineMetadata(METADATA_KEY.excludeFromIndexes, excludeFromIndexes, target);
   };
 }

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -48,3 +48,14 @@ export function id(validationOptions?: ValidationOptions) {
     });
   };
 }
+
+/**
+ * The field decorated will be unindexed.
+ */
+export function unindexed() {
+  return (target: object, propertyKey: string) => {
+    let unIndexedFields = Reflect.getMetadata(METADATA_KEY.unindexed, target) || [];
+    unIndexedFields.push(propertyKey);
+    Reflect.defineMetadata(METADATA_KEY.unindexed, unIndexedFields, target);
+  };
+}

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -2,6 +2,7 @@ import {decorate, injectable} from "inversify";
 import {CONTRAINTS, METADATA_KEY} from "./constants";
 import {interfaces} from "./interfaces";
 import {registerDecorator, ValidationOptions} from "class-validator";
+import EntityOptions = interfaces.EntityOptions;
 
 /**
  * Decorates a Google Datastore Repository
@@ -22,9 +23,14 @@ export function repository(entityIdentifier: any) {
 /**
  * Decorates an entity.
  * @param kind the kind name of an entity.
+ * @param entityOptions the options for serialization
  */
-export function entity(kind: string) {
-  return Reflect.metadata(METADATA_KEY.entity, kind);
+export function entity(kind: string, entityOptions?: EntityOptions) {
+  const metadata: interfaces.EntityMedata = {
+    kind: kind,
+    entityOptions: entityOptions
+  };
+  return Reflect.metadata(METADATA_KEY.entity, metadata);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {entity, id, repository} from "./decorators";
+import {entity, id, repository, unindexed} from "./decorators";
 import {interfaces} from "./interfaces";
 import {BaseRepository} from "./base_repository";
 import {EntityValidationError, Filter, Namespaced, Operator, Order, QueryRequest} from "./types";
@@ -7,6 +7,7 @@ import {TYPES} from "./constants";
 export {
   entity,
   id,
+  unindexed,
   repository,
   interfaces,
   BaseRepository,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {entity, id, repository, unindexed} from "./decorators";
+import {entity, id, repository, excludeFromIndex} from "./decorators";
 import {interfaces} from "./interfaces";
 import {BaseRepository} from "./base_repository";
 import {EntityValidationError, Filter, Namespaced, Operator, Order, QueryRequest} from "./types";
@@ -7,7 +7,7 @@ import {TYPES} from "./constants";
 export {
   entity,
   id,
-  unindexed,
+  excludeFromIndex,
   repository,
   interfaces,
   BaseRepository,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -7,6 +7,15 @@ namespace interfaces {
     entityIdentifier: EntityIdentifier<any>;
   }
 
+  export interface EntityMedata {
+    kind: string;
+    entityOptions?: EntityOptions;
+  }
+
+  export interface EntityOptions {
+    excludeExtraneousValues?: false | true;
+  }
+
   export interface CrudRepository<T> {
 
     /**

--- a/test/base_repository.test.ts
+++ b/test/base_repository.test.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai";
 
-import {BaseRepository, entity, id, repository, TYPES} from "../src";
+import {BaseRepository, entity, id, repository, TYPES, unindexed} from "../src";
 import {Container} from "inversify";
 import {Datastore} from "@google-cloud/datastore";
 import {anything, capture, instance, mock, verify, when} from "ts-mockito";
@@ -24,6 +24,8 @@ describe("Unit Test: BaseRepository", () => {
     class MyEntity {
       @id()
       public entityId: string;
+      @unindexed()
+      public unindexedProperty: string;
     }
 
     @repository(MyEntity)
@@ -37,6 +39,7 @@ describe("Unit Test: BaseRepository", () => {
     // Give Parameters
     const t = new MyEntity();
     t.entityId = "foo";
+    t.unindexedProperty = "bar";
 
     let mockKey = {};
 
@@ -53,6 +56,7 @@ describe("Unit Test: BaseRepository", () => {
       expect(result).eql(t);
       expect(saveRequest.key).eql(mockKey);
       expect(saveRequest.data).eql(t);
+      expect(saveRequest.excludeFromIndexes).contains("unindexedProperty");
 
       done();
     });

--- a/test/base_repository.test.ts
+++ b/test/base_repository.test.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai";
 
-import {BaseRepository, entity, id, repository, TYPES, unindexed} from "../src";
+import {BaseRepository, entity, excludeFromIndex, id, repository, TYPES} from "../src";
 import {Container} from "inversify";
 import {Datastore} from "@google-cloud/datastore";
 import {anything, capture, instance, mock, verify, when} from "ts-mockito";
@@ -24,7 +24,7 @@ describe("Unit Test: BaseRepository", () => {
     class MyEntity {
       @id()
       public entityId: string;
-      @unindexed()
+      @excludeFromIndex()
       public unindexedProperty: string;
     }
 

--- a/test/decorators.test.ts
+++ b/test/decorators.test.ts
@@ -1,8 +1,8 @@
 import {expect} from "chai";
-import {entity, id, interfaces, repository, unindexed} from "../src";
+import {entity, excludeFromIndex, id, interfaces, repository} from "../src";
 import {METADATA_KEY} from "../src/constants";
 
-describe("Unit Test: Repository Decorators", () => {
+describe("Unit Test: Decorators", () => {
 
   it("should add repository metadata to a class when decorated with @repository", (done) => {
 
@@ -23,9 +23,6 @@ describe("Unit Test: Repository Decorators", () => {
     expect(repositoryMetadata.entityIdentifier).eql(MyEntity);
     done();
   });
-});
-
-describe("Unit Test: Entity Decorators", () => {
 
   it("should add repository metadata to a class when decorated with @entity", (done) => {
 
@@ -33,10 +30,6 @@ describe("Unit Test: Entity Decorators", () => {
     class MyEntity {
       @id()
       public entityId: string;
-      @unindexed()
-      public unindexedField1: string;
-      @unindexed()
-      public unindexedField2: number[];
     }
 
     let kind: string = Reflect.getMetadata(
@@ -49,15 +42,30 @@ describe("Unit Test: Entity Decorators", () => {
         new MyEntity()
     );
 
-    let unindexedFields: string[] = Reflect.getMetadata(
-        METADATA_KEY.unindexed,
+    expect(kind).eql("MyEntityKind");
+    expect(entityId).eql("entityId");
+    done();
+  });
+
+  it("should add excludeFromIndexes metadata to a class when properties was decorated with @excludeFromIndex", (done) => {
+
+    @entity("MyEntityKind")
+    class MyEntity {
+      @id()
+      public entityId: string;
+      @excludeFromIndex()
+      public excludedField1: string;
+      @excludeFromIndex()
+      public excludedField2: number[];
+    }
+
+    let excludeFromIndexes: string[] = Reflect.getMetadata(
+        METADATA_KEY.excludeFromIndexes,
         new MyEntity()
     );
 
-    expect(kind).eql("MyEntityKind");
-    expect(entityId).eql("entityId");
-    expect(unindexedFields).contains("unindexedField1");
-    expect(unindexedFields).contains("unindexedField2");
+    expect(excludeFromIndexes).contains("excludedField1");
+    expect(excludeFromIndexes).contains("excludedField2");
     done();
   });
 });

--- a/test/decorators.test.ts
+++ b/test/decorators.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import {entity, id, interfaces, repository} from "../src";
+import {entity, id, interfaces, repository, unindexed} from "../src";
 import {METADATA_KEY} from "../src/constants";
 
 describe("Unit Test: Repository Decorators", () => {
@@ -33,6 +33,10 @@ describe("Unit Test: Entity Decorators", () => {
     class MyEntity {
       @id()
       public entityId: string;
+      @unindexed()
+      public unindexedField1: string;
+      @unindexed()
+      public unindexedField2: number[];
     }
 
     let kind: string = Reflect.getMetadata(
@@ -45,8 +49,15 @@ describe("Unit Test: Entity Decorators", () => {
         new MyEntity()
     );
 
+    let unindexedFields: string[] = Reflect.getMetadata(
+        METADATA_KEY.unindexed,
+        new MyEntity()
+    );
+
     expect(kind).eql("MyEntityKind");
     expect(entityId).eql("entityId");
+    expect(unindexedFields).contains("unindexedField1");
+    expect(unindexedFields).contains("unindexedField2");
     done();
   });
 });

--- a/test/decorators.test.ts
+++ b/test/decorators.test.ts
@@ -26,16 +26,19 @@ describe("Unit Test: Decorators", () => {
 
   it("should add repository metadata to a class when decorated with @entity", (done) => {
 
-    @entity("MyEntityKind")
+    @entity("MyEntityKind", {excludeExtraneousValues: true})
     class MyEntity {
       @id()
       public entityId: string;
     }
 
-    let kind: string = Reflect.getMetadata(
+    let metadata: interfaces.EntityMedata = Reflect.getMetadata(
         METADATA_KEY.entity,
         MyEntity
     );
+
+    let kind: string = metadata.kind;
+    let entityOptions = metadata.entityOptions;
 
     let entityId: string = Reflect.getMetadata(
         METADATA_KEY.entityId,
@@ -43,6 +46,8 @@ describe("Unit Test: Decorators", () => {
     );
 
     expect(kind).eql("MyEntityKind");
+    expect(entityOptions
+        && entityOptions.excludeExtraneousValues).eql(true);
     expect(entityId).eql("entityId");
     done();
   });


### PR DESCRIPTION
* Update [Wiki](https://github.com/pflima92/google-cloud-datastore-inversify/wiki)
* Fix filter `Opeartors`
* Add `excludeFromIndex` decorator to exclude a specific property from indexes
* Add `entityOptions` for custom configurations
* Add `excludeExtraneousValues` that allows ensure all properties from the type class